### PR TITLE
Use Throwable in REST wrapper

### DIFF
--- a/gpt-4-wp-plugin-v1.2.php
+++ b/gpt-4-wp-plugin-v1.2.php
@@ -30,7 +30,7 @@ function gpt_rest_api_error_wrapper($callback)
                 return $result;
             }
             return $result;
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             if (defined('GPT_PLUGIN_DEBUG') && GPT_PLUGIN_DEBUG) {
                 error_log('[GPT-4-WP-Plugin] Exception: ' . $e->getMessage());
             }


### PR DESCRIPTION
## Summary
- handle all throwables in REST wrapper so PHP errors are returned via JSON

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddda044648329b5c1ce77b8f0a011