### PR TITLE
Improve API key error message

### DIFF
--- a/gpt-4-wp-plugin-v1.2.php
+++ b/gpt-4-wp-plugin-v1.2.php
@@ -387,7 +387,7 @@ function gpt_rest_permission_check_role($request)
     $key = $request->get_header('gpt-api-key');
     $role = gpt_get_role_for_key($key);
     if (!$role) {
-        return false;
+        return gpt_error_response('Invalid or missing API key.', 401);
     }
     $request->set_param('gpt_role', $role);
     // Route-specific permission logic


### PR DESCRIPTION
## Summary
- show a clearer API error when the API key is invalid or missing

## Testing
- `php -l gpt-4-wp-plugin-v1.2.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddd9baffc8329b7aed84839440c6f