### PR TITLE
Fix OpenAPI components

### DIFF
--- a/gpt-4-wp-plugin-v1.2.php
+++ b/gpt-4-wp-plugin-v1.2.php
@@ -617,6 +617,26 @@ function gpt_openapi_schema_handler()
                     'in' => 'header',
                     'name' => 'gpt-api-key',
                 ]
+            ],
+            'schemas' => [
+                'PostInput' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'title' => ['type' => 'string'],
+                        'content' => ['type' => 'string'],
+                        'excerpt' => ['type' => 'string'],
+                        'categories' => ['type' => 'array', 'items' => ['type' => 'integer']],
+                        'tags' => ['type' => 'array', 'items' => ['oneOf' => [['type' => 'string'], ['type' => 'integer']]]],
+                        'featured_image' => ['type' => 'integer'],
+                        'format' => ['type' => 'string'],
+                        'slug' => ['type' => 'string'],
+                        'author' => ['type' => 'integer'],
+                        'post_status' => ['type' => 'string'],
+                        'post_date' => ['type' => 'string'],
+                        'meta' => ['type' => 'object', 'additionalProperties' => ['type' => 'string']]
+                    ],
+                    'required' => ['title', 'content']
+                ]
             ]
         ],
         'security' => [['ApiKeyAuth' => []]],
@@ -716,28 +736,6 @@ function gpt_openapi_schema_handler()
                             ]
                         ]
                     ]
-                ]
-            ]
-        ],
-        'components' => [
-            'schemas' => [
-                'PostInput' => [
-                    'type' => 'object',
-                    'properties' => [
-                        'title' => ['type' => 'string'],
-                        'content' => ['type' => 'string'],
-                        'excerpt' => ['type' => 'string'],
-                        'categories' => ['type' => 'array', 'items' => ['type' => 'integer']],
-                        'tags' => ['type' => 'array', 'items' => ['oneOf' => [['type' => 'string'], ['type' => 'integer']]]],
-                        'featured_image' => ['type' => 'integer'],
-                        'format' => ['type' => 'string'],
-                        'slug' => ['type' => 'string'],
-                        'author' => ['type' => 'integer'],
-                        'post_status' => ['type' => 'string'],
-                        'post_date' => ['type' => 'string'],
-                        'meta' => ['type' => 'object', 'additionalProperties' => ['type' => 'string']]
-                    ],
-                    'required' => ['title', 'content']
                 ]
             ]
         ]


### PR DESCRIPTION
## Summary
- keep security schemes and schemas in the same `components` block

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685ddd9646ec8329a2e9ad085617611d