### PR TITLE
Update API schema

### DIFF
--- a/gpt-4-wp-plugin-v2.0.php
+++ b/gpt-4-wp-plugin-v2.0.php
@@ -907,6 +907,14 @@ function gpt_openapi_schema_handler()
                 'post' => [
                     'summary' => 'Create a new post',
                     'operationId' => 'createPost',
+                    'parameters' => [
+                        [
+                            'name' => 'gpt_role',
+                            'in' => 'query',
+                            'required' => true,
+                            'schema' => ['type' => 'string']
+                        ]
+                    ],
                     'requestBody' => [
                         'required' => true,
                         'content' => [
@@ -940,6 +948,12 @@ function gpt_openapi_schema_handler()
                             'in' => 'path',
                             'required' => true,
                             'schema' => ['type' => 'integer']
+                        ],
+                        [
+                            'name' => 'gpt_role',
+                            'in' => 'query',
+                            'required' => true,
+                            'schema' => ['type' => 'string']
                         ]
                     ],
                     'requestBody' => [
@@ -969,6 +983,14 @@ function gpt_openapi_schema_handler()
                 'post' => [
                     'summary' => 'Upload a media file',
                     'operationId' => 'uploadMedia',
+                    'parameters' => [
+                        [
+                            'name' => 'gpt_role',
+                            'in' => 'query',
+                            'required' => true,
+                            'schema' => ['type' => 'string']
+                        ]
+                    ],
                     'requestBody' => [
                         'required' => true,
                         'content' => [
@@ -976,7 +998,8 @@ function gpt_openapi_schema_handler()
                                 'schema' => [
                                     'type' => 'object',
                                     'properties' => [
-                                        'file' => ['type' => 'string', 'format' => 'binary']
+                                        'file' => ['type' => 'string', 'format' => 'binary'],
+                                        'image_url' => ['type' => 'string']
                                     ]
                                 ]
                             ]


### PR DESCRIPTION
## Summary
- document required `gpt_role` query parameter for `/post`, `/post/{id}` and `/media`
- allow optional `image_url` in media upload schema

## Testing
- `php -l gpt-4-wp-plugin-v2.0.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8b1d367883298c3c591e3d234f83