### PR TITLE
Ensure rewrite rules refresh on plugin lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A clean, modern WordPress plugin providing a secure REST API for GPT-based agent
   - REST endpoint diagnostics and status (now split into two columns for clarity)
   - Recent API error log display
 - **All code in a single file:** Easy to install, portable, and maintainable
+- **Automatic permalink flush on activation/deactivation:** REST routes work immediately without manual resets
 
 ---
 

--- a/gpt-4-wp-plugin-v2.0.php
+++ b/gpt-4-wp-plugin-v2.0.php
@@ -82,6 +82,8 @@ register_activation_hook(__FILE__, function () {
         'edit_posts' => true,
         'upload_files' => true,
     ]);
+    // Flush rewrite rules so REST routes are registered without requiring a permalink reset
+    flush_rewrite_rules();
 });
 
 // --- Remove custom roles on deactivation ---
@@ -90,6 +92,8 @@ register_deactivation_hook(__FILE__, function () {
     remove_role('gpt_webmaster');
     remove_role('gpt_publisher');
     remove_role('gpt_editor');
+    // Flush rewrite rules so REST routes are removed cleanly
+    flush_rewrite_rules();
 });
 
 // --- API Key Management: Admin UI ---


### PR DESCRIPTION
## Summary
- auto flush permalink rules after registering/removing roles
- document automatic flush in README

## Testing
- `php -l gpt-4-wp-plugin-v2.0.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f8b4219a083298f4ae350eb1874b5