### PR TITLE
Implement post scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ All endpoints require the `gpt-api-key` header with a valid API key.
   }
 }
 ```
+If `post_date` is set to a future time, the plugin will schedule the post by automatically setting its status to `future`.
 - **Response (200):**
 ```json
 {


### PR DESCRIPTION
## Summary
- schedule posts when `post_date` is in the future
- document new scheduling behavior in README
- expose scheduling rules in the OpenAPI schema

## Testing
- `php -l gpt-4-wp-plugin-v2.0.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff6de5150832990405b0c1a72775d