### PR TITLE
Fix folder reference in manifest comment

### DIFF
--- a/gpt-4-wp-plugin-v2.0.php
+++ b/gpt-4-wp-plugin-v2.0.php
@@ -1050,7 +1050,7 @@ function gpt_ai_plugin_manifest_handler()
 {
     $site_url = get_site_url();
     // Build the plugin URL dynamically so the manifest works regardless of the
-    // actual plugin directory name (e.g. gpt-4-wp-plugin-v2.0).
+    // actual plugin directory name (e.g. gpt-4-wp-plugin).
     $plugin_url = plugin_dir_url(__FILE__);
     $manifest = [
         'schema_version' => 'v1',


### PR DESCRIPTION
## Summary
- correct example folder name in manifest comment referencing `gpt-4-wp-plugin`

## Testing
- `php -l gpt-4-wp-plugin-v2.0.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9611fc408329aaadcea661e1f686