### PR TITLE
Restrict featured image uploads to image files

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,11 @@ If `post_date` is set to a future time, the plugin will schedule the post by aut
 - **Headers:**
   - `Content-Type: multipart/form-data`
   - `gpt-api-key: YOUR_API_KEY`
+- **Query Params:**
+  - `post_id` *(optional)*: attach the upload to a post
+  - `featured` *(optional, boolean)*: set to `true` when uploading a featured image
 - **Body:**
-  - `file`: (binary file upload)
+  - `file`: (binary file upload) or `image_url`: URL to download the image
 - **Response (200):**
 ```json
 {
@@ -179,6 +182,8 @@ If `post_date` is set to a future time, the plugin will schedule the post by aut
   "data": {"status": 400}
 }
 ```
+
+When `post_id` or `featured` is used, the upload is treated as a featured image and **must** be an image file (`image/*`).
 
 ### 5. **Plugin File Management (gpt_admin only)**
 > **Note:** These endpoints are only available to API keys with the `gpt_admin` role (e.g. WebMaster.GPT). All file/folder access is strictly limited to the plugin directory for security.

--- a/gpt-4-wp-plugin-v2.0.php
+++ b/gpt-4-wp-plugin-v2.0.php
@@ -642,6 +642,11 @@ add_action('rest_api_init', function () {
                     return is_numeric($value);
                 },
             ],
+            'featured' => [
+                'validate_callback' => function ($value) {
+                    return in_array(strtolower($value), ['1', '0', 'true', 'false', 1, 0], true);
+                },
+            ],
         ],
     ]);
     register_rest_route('gpt/v1', '/openapi', [
@@ -992,6 +997,7 @@ function gpt_upload_media_endpoint($request)
     }
 
     $post_id = $request->get_param('post_id');
+    $featured = $request->get_param('featured');
 
     $uploads = wp_upload_dir();
     if (!empty($uploads['error']) || !is_writable($uploads['path'])) {
@@ -1008,6 +1014,12 @@ function gpt_upload_media_endpoint($request)
         'application/x-msdownload'
     ];
     $allowed_mimes = array_diff($allowed_mimes, $dangerous_mimes);
+    $is_featured = $post_id || filter_var($featured, FILTER_VALIDATE_BOOLEAN);
+    if ($is_featured) {
+        $allowed_mimes = array_filter($allowed_mimes, function ($mime) {
+            return strpos($mime, 'image/') === 0;
+        });
+    }
 
     // --- Support direct file uploads via $_FILES['file'] ---
     if (!empty($_FILES['file']) && isset($_FILES['file']['tmp_name']) && is_uploaded_file($_FILES['file']['tmp_name'])) {
@@ -1253,6 +1265,7 @@ function gpt_openapi_schema_handler()
             '/media' => [
                 'post' => [
                     'summary' => 'Upload a media file',
+                    'description' => 'If `post_id` or `featured` is provided, only image files are allowed.',
                     'operationId' => 'uploadMedia',
                     'parameters' => [
                         [
@@ -1266,6 +1279,12 @@ function gpt_openapi_schema_handler()
                             'in' => 'query',
                             'required' => false,
                             'schema' => ['type' => 'integer']
+                        ],
+                        [
+                            'name' => 'featured',
+                            'in' => 'query',
+                            'required' => false,
+                            'schema' => ['type' => 'boolean']
                         ]
                     ],
                     'requestBody' => [


### PR DESCRIPTION
## Summary
- require images only when uploading a featured image
- document post_id and featured options for `/media` uploads
- note restriction in OpenAPI schema and README

## Testing
- `php -l gpt-4-wp-plugin-v2.0.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860325163408329840f013d689bc9cf