### PR TITLE
Return error on invalid edit post_date

### DIFF
--- a/gpt-4-wp-plugin-v2.0.php
+++ b/gpt-4-wp-plugin-v2.0.php
@@ -924,7 +924,10 @@ function gpt_edit_post_endpoint($request)
     // If the provided post_date is in the future, set post_status to 'future'
     if (!empty($update['post_date'])) {
         $timestamp = strtotime($update['post_date']);
-        if ($timestamp !== false && $timestamp > current_time('timestamp')) {
+        if ($timestamp === false) {
+            return gpt_error_response('Invalid post_date', 400);
+        }
+        if ($timestamp > current_time('timestamp')) {
             $update['post_status'] = 'future';
         }
     }


### PR DESCRIPTION
## Summary
- validate `post_date` during edit post operations

## Testing
- `php -l gpt-4-wp-plugin-v2.0.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860393f8c748329a8b623372b2a72d7