### PR TITLE
Add example for post_date rescheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ If `post_date` is set to a future time, the plugin will schedule the post by aut
   "content": "Updated content"
 }
 ```
+To reschedule an existing post, pass a new `post_date` value. If the supplied
+time is in the future the post will be scheduled automatically and its status
+set to `future`.
+```json
+{
+  "post_date": "2025-06-30 09:00:00"
+}
+```
 - **Response (200):**
 ```json
 {


### PR DESCRIPTION
## Summary
- document how to reschedule a post using `post_date` in the Edit Post section

## Testing
- `php -l gpt-4-wp-plugin-v2.0.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6860394396e08329b9cc552940783674