### PR TITLE
Update API schema docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ All endpoints require the `gpt-api-key` header with a valid API key.
   "featured_image": 123,
   "format": "standard",
   "slug": "my-article-title",
-  "author": 2,
   "post_status": "publish",
   "post_date": "2025-06-26 10:00:00",
   "meta": {
@@ -115,10 +114,16 @@ All endpoints require the `gpt-api-key` header with a valid API key.
 }
 ```
 If `post_date` is set to a future time, the plugin will schedule the post by automatically setting its status to `future`.
-- **Response (200):**
+- **Response (201):**
 ```json
 {
-  "post_id": 1234
+  "post_id": 1234,
+  "post_status": "publish",
+  "author": 2,
+  "meta": {
+    "_yoast_wpseo_metadesc": "SEO meta description",
+    "_rank_math_focus_keyword": "focus keyword"
+  }
 }
 ```
 - **Response (error):**
@@ -150,10 +155,11 @@ set to `future`.
   "post_date": "2025-06-30 09:00:00"
 }
 ```
-- **Response (200):**
+ - **Response (200):**
 ```json
 {
-  "post_id": 1234
+  "post_id": 1234,
+  "post_status": "publish"
 }
 ```
 - **Response (error):**

--- a/gpt-4-wp-plugin-v2.0.php
+++ b/gpt-4-wp-plugin-v2.0.php
@@ -1244,7 +1244,6 @@ function gpt_openapi_schema_handler()
                         ],
                         'format' => ['type' => 'string'],
                         'slug' => ['type' => 'string'],
-                        'author' => ['type' => 'integer'],
                         'post_status' => ['type' => 'string', 'description' => 'Desired status (may be overridden to "future" if post_date is in the future)'],
                         'post_date' => ['type' => 'string', 'description' => 'Publish date/time (Y-m-d H:i:s). Future dates schedule the post'],
                         'meta' => ['type' => 'object', 'additionalProperties' => ['type' => 'string']]
@@ -1276,13 +1275,18 @@ function gpt_openapi_schema_handler()
                         ]
                     ],
                     'responses' => [
-                        '200' => [
+                        '201' => [
                             'description' => 'Post created',
                             'content' => [
                                 'application/json' => [
                                     'schema' => [
                                         'type' => 'object',
-                                        'properties' => ['post_id' => ['type' => 'integer']]
+                                        'properties' => [
+                                            'post_id' => ['type' => 'integer'],
+                                            'post_status' => ['type' => 'string'],
+                                            'author' => ['type' => 'integer'],
+                                            'meta' => ['type' => 'object', 'additionalProperties' => ['type' => 'string']]
+                                        ]
                                     ]
                                 ]
                             ]
@@ -1323,7 +1327,10 @@ function gpt_openapi_schema_handler()
                                 'application/json' => [
                                     'schema' => [
                                         'type' => 'object',
-                                        'properties' => ['post_id' => ['type' => 'integer']]
+                                        'properties' => [
+                                            'post_id' => ['type' => 'integer'],
+                                            'post_status' => ['type' => 'string']
+                                        ]
                                     ]
                                 ]
                             ]


### PR DESCRIPTION
## Summary
- remove `author` from `PostInput`
- document returned fields in the OpenAPI schema
- update README examples to match the new API behavior

## Testing
- `php -l gpt-4-wp-plugin-v2.0.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686042cc195083299d71ae81151896af